### PR TITLE
Update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# Installation Instructions
+
+mkdir ~/.go
+export GOPATH=~/.go
+go get github.com/lucy/tewisay
+
 Features
 --------
 * Correct width for unicode and ANSI escapes
@@ -5,3 +11,4 @@ Features
 TODO
 ----
 * (maybe?) Wrapping
+* Read cowfiles from $COWPATH

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # Installation Instructions
 
+```
 mkdir ~/.go
+
 export GOPATH=~/.go
+
 go get github.com/lucy/tewisay
+```
 
 Features
 --------

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/lucy/runewidth"
+	"github.com/mattn/go-runewidth"
 	flag "github.com/ogier/pflag"
 )
 


### PR DESCRIPTION
Since `github.com/lucy/runewidth` doesn't exist any more, I just swapped out this dependency with `github.com/mattn/go-runewidth` and updated the code accordingly. 

(I don't know if this introduces any bugs yet, but everything seems to compile and run fine on my end!)